### PR TITLE
gccrs: fix ICE on empty constexpr loops

### DIFF
--- a/gcc/rust/backend/rust-constexpr.cc
+++ b/gcc/rust/backend/rust-constexpr.cc
@@ -1901,6 +1901,9 @@ eval_constant_expression (const constexpr_ctx *ctx, tree t, bool lval,
 
   location_t loc = EXPR_LOCATION (t);
 
+  if (t == NULL_TREE)
+    return NULL_TREE;
+
   if (CONSTANT_CLASS_P (t))
     {
       if (TREE_OVERFLOW (t))

--- a/gcc/testsuite/rust/compile/issue-3618.rs
+++ b/gcc/testsuite/rust/compile/issue-3618.rs
@@ -1,0 +1,1 @@
+static _X: () = loop {}; // { dg-error "loop iteration count exceeds limit" }


### PR DESCRIPTION
Empty loops have no body which means this is a NULL_TREE during const evaluation which needs a check. Fixes Rust-GCC #3618.

gcc/rust/ChangeLog:

	* backend/rust-constexpr.cc (eval_constant_expression):  Check if t is a NULL_TREE

gcc/testsuite/ChangeLog:

	* rust/compile/issue-3618.rs: Test empty loops error properly.
